### PR TITLE
Modernize Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
   - linux
 julia:
   - 0.4
+  - 0.5
   - nightly
 notifications:
 email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,11 @@
-language: cpp
-compiler:
-  - clang
+language: julia
+os:
+  - osx
+  - linux
+julia:
+  - 0.4
+  - nightly
 notifications:
-  email: false
-before_install:
-  - sudo add-apt-repository ppa:staticfloat/julia-deps -y
-  - sudo add-apt-repository ppa:staticfloat/juliareleases -y
-  - sudo apt-get update -qq -y
-  - sudo apt-get install libpcre3-dev julia -y
-script:
-  - julia -e 'Pkg.init(); run(`ln -s $(pwd()) $(Pkg.dir("LinearLeastSquares"))`); Pkg.pin("LinearLeastSquares"); Pkg.resolve()'
-  - julia -e 'using LinearLeastSquares; @assert isdefined(:LinearLeastSquares); @assert typeof(LinearLeastSquares) === Module'
-  - julia --code-coverage test/runtests.jl
+email: false
 after_success:
   - julia -e 'cd(Pkg.dir("LinearLeastSquares")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'


### PR DESCRIPTION
This allows testing against both osx and linux, and the nightlies
are more up to date than the PPA

the default value of `script` is usually probably fine for testing most packages