### PR TITLE
julia 0.5 deprecation: ASCIIString -> String

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.4
+Compat

--- a/examples/machine_learning/MatrixMarket.jl
+++ b/examples/machine_learning/MatrixMarket.jl
@@ -2,7 +2,7 @@
 
 module MatrixMarket
 
-function mmread(filename::ASCIIString, infoonly::Bool)
+function mmread(filename::String, infoonly::Bool)
 #      Reads the contents of the Matrix Market file 'filename'
 #      into a matrix, which will be either sparse or dense,
 #      depending on the Matrix Market format indicated by
@@ -45,6 +45,6 @@ function mmread(filename::ASCIIString, infoonly::Bool)
   reshape([float64(readline(mmfile)) for i in 1:entries], (rows,cols))
 end
 
-mmread(filename::ASCIIString) = mmread(filename, false)
+mmread(filename::String) = mmread(filename, false)
 
 end # module

--- a/src/LinearLeastSquares.jl
+++ b/src/LinearLeastSquares.jl
@@ -1,5 +1,8 @@
 module LinearLeastSquares
 
+using Compat
+import Compat.String
+
 include("types/expressions.jl")
 include("types/constraints.jl")
 include("types/problems.jl")

--- a/src/types/problems.jl
+++ b/src/types/problems.jl
@@ -7,7 +7,7 @@ type Problem
   head::Symbol
   objective::SumSquaresExpr
   constraints::Array{EqConstraint, 1}
-  status::ASCIIString
+  status::String
   optval::Float64OrVoid
 
   function Problem(head::Symbol, objective::SumSquaresExprOrVoid, constraints::Array{EqConstraint, 1})


### PR DESCRIPTION
Hi,

Here are some fixes to the warnings associated with ASCIIString when using Julia 0.5.

I've tested this change on Julia 0.4 and 0.5 and it seems to work.

Thanks!